### PR TITLE
Expose `unix_sysv` feature in `slice-ring-buffer`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ thiserror = "1.0.23"
 [features]
 default = []
 async_tokio = ["tokio"]
-unix_sysv = ["slice_ring_buffer/unix_sysv"]
+unix_sysv = ["slice-ring-buffer/unix_sysv"]
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ thiserror = "1.0.23"
 [features]
 default = []
 async_tokio = ["tokio"]
+unix_sysv = ["slice_ring_buffer/unix_sysv"]
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["full"] }


### PR DESCRIPTION
slice-ring-buffer with default features uses a custom allocator that calls non-public Apple API symbols, causing any app using it to fail Apple's review process. The unix_sysv features allows us to fallback to an implementation that avoid these private API calls and lets us pass App Store Connect review.